### PR TITLE
Moves filtered by class and level

### DIFF
--- a/Assets/Scripts/Battle/BattleChar.cs
+++ b/Assets/Scripts/Battle/BattleChar.cs
@@ -18,7 +18,7 @@ public class BattleChar : MonoBehaviour
     public SpriteRenderer theSprite;
     public Sprite deadSprite, aliveSprite;
 
-
+    public bool isDead => currentHp <= 0;
     private bool shouldFade;
     public float fadeSpeed = 1f;
 

--- a/Assets/Scripts/Battle/BattleManager.cs
+++ b/Assets/Scripts/Battle/BattleManager.cs
@@ -136,6 +136,7 @@ public class BattleManager : MonoBehaviour {
 
 
                             CharStats thePlayer = GameManager.instance.playerStats[i];
+                            activeBattlers[i].movesAvailable = thePlayer.GetAllowedMovesNames(movesList);
                             activeBattlers[i].currentHp = thePlayer.currentHP;
                             activeBattlers[i].maxHP = thePlayer.maxHP;
                             activeBattlers[i].currentMP = thePlayer.currentMP;
@@ -407,6 +408,11 @@ public class BattleManager : MonoBehaviour {
 
     public void OpenMagicMenu()
     {
+        if(activeBattlers[currentTurn].movesAvailable.Length < 1)
+        {
+            Debug.LogError("Prevented spell menu softlock add a close button and/or disable spells if move list is empty");
+            return;
+        }
         magicMenu.SetActive(true);
 
         for(int i = 0; i < magicButtons.Length; i++)

--- a/Assets/Scripts/Battle/BattleMove.cs
+++ b/Assets/Scripts/Battle/BattleMove.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -7,8 +8,73 @@ using UnityEngine;
 [System.Serializable]
 public class BattleMove {
 
+    public enum CharacterClass
+    {
+        Cleric,Druid,Fighter,MagicUser,Paladin,Ranger,Thief
+    }
+
+    public enum MoveFilterMode
+    {
+        DisallowMoveForClassIfNotListed,OverrideDefaultLevelForClass
+    }
+
+    [System.Serializable]
+    public class MoveFilter
+    {
+        public CharacterClass characterClass;
+        public int minimumLevel;
+    }
+
     public string moveName;
     public int movePower;
     public int moveCost;
+    public bool allowOutsideBattle;
     public AttackEffect theEffect;
+
+    [Header("Move Filter")]
+    public MoveFilterMode filterAction;
+    public int defaultMinimumLevel = 0;
+    [UnityEngine.Serialization.FormerlySerializedAs("prerequisite")]
+    public MoveFilter[] classSpecificFilter;
+
+
+    public bool MoveAllowedOutsideBattle(CharStats character)
+    {
+        return MoveAllowed(character) && allowOutsideBattle;
+    }
+    public bool MoveAllowed(CharStats character)
+    {
+        int? lvl = MinLevelForClass(character.characterClass);
+#pragma warning disable CS0162 // Unreachable code detected
+        switch (filterAction)
+        {
+            case MoveFilterMode.DisallowMoveForClassIfNotListed:
+                return lvl != null && character.playerLevel >= lvl;
+                break;
+
+            case MoveFilterMode.OverrideDefaultLevelForClass:
+                return lvl == null? character.playerLevel >= defaultMinimumLevel : character.playerLevel>=lvl;
+                break;
+        }
+#pragma warning restore CS0162 // Unreachable code detected
+        return false;
+        
+    }
+
+    private int? MinLevelForClass(CharacterClass characterClass)
+    {
+        foreach(var f in classSpecificFilter)
+        {
+            if(f.characterClass == characterClass)
+            {
+                return f.minimumLevel;
+            }
+        }
+        return null;
+    }
+
+    internal void Apply(CharStats charStats)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/Assets/Scripts/Character Creation/CharStats.cs
+++ b/Assets/Scripts/Character Creation/CharStats.cs
@@ -8,6 +8,7 @@ public class CharStats : MonoBehaviour {
 
     public string charName;
     public BattleChar battleChar;
+    public BattleMove.CharacterClass characterClass;
     public int playerLevel = 1;
     public int currentEXP;
     public int[] expToNextLevel;
@@ -34,6 +35,7 @@ public class CharStats : MonoBehaviour {
     internal string equippedOtherArmr="";
     internal string equippedShieldArmr="";
 
+    public bool isDead => currentHP <= 0;
 
     // Use this for initialization
     void Start () {
@@ -91,5 +93,29 @@ public class CharStats : MonoBehaviour {
         {
             currentEXP = 0;
         }
+    }
+
+    public bool ApplyMove(CharStats caster, BattleMove move)
+    {
+        if(caster.currentMP>=move.moveCost)
+        {
+            caster.currentMP -= move.moveCost;
+            move.Apply(this);
+            return true;
+        }
+        return false;
+    }
+
+    internal string[] GetAllowedMovesNames(BattleMove[] movesList,bool inBattle=true)
+    {
+        List<string> l = new List<string>();
+        foreach(var m in movesList)
+        {
+            if(m.MoveAllowed(this))
+            {
+                l.Add(m.moveName);
+            }
+        }
+        return l.ToArray();
     }
 }


### PR DESCRIPTION
- Set the class of the character in its `charStats`
- `BattleMnager.movesList` is the moves database, set filter criteria to allow or deny a move.
- You can either restrict all classes to only get the move later or only permit certain classes to get the move.  Change this behavior by changing the filter mode.  remember to set the default unlocking level.